### PR TITLE
Raise exceptions on missing/unknown author data

### DIFF
--- a/plugins/author_box.rb
+++ b/plugins/author_box.rb
@@ -6,6 +6,16 @@ module Jekyll
     def post_render(post)
       if post.is_post?
         authors = YAML::load(File.open(File.expand_path('../../author.yml', __FILE__)))
+
+        if !post.data.key? 'author'
+          raise "No author specified in post '#{post.data['title']}'"
+        end
+
+        authorName = post.data['author']
+        if !authors.key? authorName
+          raise "Could not find author data for '#{authorName}' in post '#{post.data['title']}'"
+        end
+
         author = authors[post.data["author"]]
         post.content << render_content(author)
       end


### PR DESCRIPTION
Currently, a post without an author or with an author that's not in author.yml apparently causes post generation to silently fail... This was rather confusing when getting a new author going on one of my octopress installs.

I haven't debugged why it's failing silently, so perhaps there's a deeper problem here, but either way it seems like if you're using the author plugin you probably want to know if you don't have an author set. :)
